### PR TITLE
feat: support templates from ad server url & status check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "actix-cors",
  "actix-http",
  "actix-web",
+ "async-lock",
  "awc",
  "chrono",
  "clap",
@@ -445,6 +446,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -811,6 +823,15 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1225,6 +1246,27 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2422,6 +2464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,9 +3407,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ name = "mp4_parser"
 path = "src/mp4_parser.rs"
 
 [dependencies]
+dash-mpd = "0.17.3"
+hls_m3u8 = { version = "0.4.2", features = ["backtrace"] }
+vast4-rs = "1.0.6"
+mp4 = "0.14.0"
+
 awc = { version = "3.5.1", features = ["rustls-0_23"] }
 actix = "0.13.5"
 actix-web = { version = "4.9.0", features = ["openssl"] }
@@ -51,7 +56,7 @@ rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = "0.3"
-tokio = { version = "1.24.2", features = ["sync", "io-util"] }
+tokio = { version = "1.41.1", features = ["sync", "io-util"] }
 tokio-util = "0.7.4"
 tokio-stream = { version = "0.1.3", features = ["sync"] }
 tracing = "0.1.30"
@@ -63,8 +68,4 @@ dashmap = "6.1.0"
 lazy_static = "1.5.0"
 webpki-roots = "0.26"
 mime = "0.3"
-
-dash-mpd = "0.17.3"
-hls_m3u8 = { version = "0.4.2", features = ["backtrace"] }
-vast4-rs = "1.0.6"
-mp4 = "0.14.0"
+async-lock = "3.4.0"

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ For example, one test ad server is available at <https://eyevinn-sgai.eyevinn-te
 ### Run
 
 ```bash
-# Start the ad-proxy server on port 3333 with the origin HLS stream (http://localhost:8001/loop/master.m3u8) and test ad server
-# Use dynamic mode to insert ads into the HLS Live stream at specified timepoints
-# Use http://localhost:3333 as the base URL for interstitals (by default)
+# Start the ad-proxy server on port 3333 with the origin HLS stream at http://localhost:8001/loop/master.m3u8
+# 1. Use test ad server at https://eyevinn-sgai.eyevinn-test-adserver.auto.prod.osaas.io/api/v1/vast with query parameters dur, uid, ps, min, and max
+# Here the [template.*] will be replaced with the actual values before sending the request to the ad server while the rest will be passed as is
+# 2. Use dynamic mode to insert ads into the HLS Live stream at specified timepoints
+# 3. Use http://localhost:3333 as the base URL for interstitals (by default)
 cargo run --bin ad_proxy 127.0.0.1 3333 http://localhost:8001/test/master.m3u8 \
-https://eyevinn-sgai.eyevinn-test-adserver.auto.prod.osaas.io/api/v1/vast -i dynamic
+https://eyevinn-sgai.eyevinn-test-adserver.auto.prod.osaas.io/api/v1/vast?dur=[template.duration]&uid=[template.sessionId]&ps=[template.pod]&min=5&max=5 \
+--ad-insertion-mode dynamic
 
 # Now you can access the HLS Live stream at http://127.0.0.1:3333/test/master.m3u8
 # NOTE: Each proxy server instance can only handle one HLS Live stream at a time and restart is required to switch streams
@@ -64,18 +67,14 @@ Arguments:
                          It should be a VAST4.0/4.1 XML compatible endpoint
 
 Options:
-  -a, --ad-server-mode <AD_SERVER_MODE>
-          Ad server to use:
-          1) default  - use default test ad server
-          2) advanced - use custom ad server [default: default] [possible values: default, advanced]
-  -i, --insertion-mode <INSERTION_MODE>
+  -a, --ad-insertion-mode <AD_INSERTION_MODE>
           Ad insertion mode to use:
           1) static  - add intertistial every 30 seconds (100 in total).
           2) dynamic - add intertistial when requested (Live Content only). [default: static] [possible values: static, dynamic]
-      --interstitals-address <INTERSTITALS_ADDRESS>
+  -i, --interstitals-address <INTERSTITALS_ADDRESS>
           Base URL for interstitals (protocol://ip:port)
           If not provided, the server will use 'localhost' and the 'listen port' as the base URL
-          e.g., http://localhost:${LISTEN_PORT}
+          e.g., http://localhost:${LISTEN_PORT} [default: ]
 ```
 
 ### Insert Ads
@@ -90,6 +89,12 @@ For example, to insert an ad break at 5 seconds from the live-edge with a durati
 
 ```bash
 curl http://127.0.0.1:3333/command?in=5&dur=10&pod=2
+```
+
+It is also possible to check the status of the proxy server by sending a GET request:  
+
+```bash
+curl http://127.0.0.1:3333/status
 ```
 
 ### Example Modified Media Playlist

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ struct AvailableAdSlots(Arc<DashSet<AdSlot>>);
 
 impl AvailableAdSlots {
     fn to_json(&self) -> json::JsonValue {
-        let mut slots = self
+        let slots = self
             .0
             .iter()
             .map(|slot| {
@@ -118,8 +118,6 @@ impl AvailableAdSlots {
                 }
             })
             .collect::<Vec<_>>();
-
-        slots.sort_by(|a, b| a["index"].as_str().cmp(&b["index"].as_str()));
 
         object! {
             "count": slots.len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 mod utils;
 use utils::{
-    base_url, build_advanced_ad_server_url, build_forward_url, build_test_ad_server_url,
-    copy_headers, fixed_offset_to_local, get_all_linears_from_vast,
-    get_duration_and_media_urls_from_linear, rustls_config,
+    base_url, build_forward_url, copy_headers, fixed_offset_to_local, get_all_linears_from_vast,
+    get_duration_and_media_urls_from_linear, get_query_param, rustls_config,
 };
 
 use actix_web::{error, middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
@@ -14,6 +13,7 @@ use hls_m3u8::types::Value;
 use hls_m3u8::MediaPlaylist;
 use hls_m3u8::MediaSegment;
 use json::object;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io;
 use std::sync::Arc;
@@ -21,11 +21,16 @@ use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
 
-const BUMPER_DURATION: u64 = 6;
-const DEFAULT_AD_DURATION: u64 = 10;
+const DEFAULT_AD_DURATION: u64 = 13;
+const DEFAULT_AD_NUMBER: i64 = 100;
 
+const STATUS_PREFIX: &str = "/status";
 const COMMAND_PREFIX: &str = "/command";
 const INTERSTITIAL_PLAYLIST: &str = "interstitials.m3u8";
+
+const SESSION_ID_TEMPLATE: &str = "[template.sessionId]";
+const DURATION_TEMPLATE: &str = "[template.duration]";
+const POD_NUM_TEMPLATE: &str = "[template.pod]";
 
 const HLS_INTERSTITIAL_ID: &str = "_HLS_interstitial_id";
 const HLS_PRIMARY_ID: &str = "_HLS_primary_id";
@@ -42,17 +47,85 @@ enum RequestType {
     MasterPlayList,
     MediaPlayList,
     Segment,
+    Other,
 }
 
 #[derive(Clone, Default)]
 struct Ad {
     duration: u64,
     url: String,
+    requested_at: chrono::DateTime<chrono::Local>,
 }
 
 #[derive(Clone, Default)]
 struct AvailableAds {
     linears: Arc<DashMap<Uuid, Ad>>,
+}
+
+impl AvailableAds {
+    fn to_json(&self) -> json::JsonValue {
+        let linears = self
+            .linears
+            .iter()
+            .map(|entry| {
+                let (id, ad) = entry.pair();
+                object! {
+                    "id": id.to_string(),
+                    "duration": ad.duration,
+                    "url": ad.url.clone(),
+                    "requested_at": ad.requested_at.to_rfc3339(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        object! {
+            "count": linears.len(),
+            "linears": linears,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AdSlot {
+    id: Uuid,
+    index: u64,
+    start_time: chrono::DateTime<chrono::Local>,
+    duration: u64,
+    pod_num: u64,
+}
+
+impl AdSlot {
+    fn name(&self) -> String {
+        format!("ad_slot{}", self.index)
+    }
+}
+
+#[derive(Clone, Default)]
+struct AvailableAdSlots(Arc<DashSet<AdSlot>>);
+
+impl AvailableAdSlots {
+    fn to_json(&self) -> json::JsonValue {
+        let mut slots = self
+            .0
+            .iter()
+            .map(|slot| {
+                object! {
+                    "id": slot.id.to_string(),
+                    "index": slot.index,
+                    "start_time": slot.start_time.to_rfc3339(),
+                    "duration": slot.duration,
+                    "pod_num": slot.pod_num,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        slots.sort_by(|a, b| a["index"].as_str().cmp(&b["index"].as_str()));
+
+        object! {
+            "count": slots.len(),
+            "slots": slots,
+        }
+    }
 }
 
 #[derive(clap::Parser, Debug)]
@@ -73,38 +146,17 @@ struct CliArguments {
     #[clap(verbatim_doc_comment)]
     ad_server_endpoint: String,
 
-    /// Ad server to use:
-    /// 1) default  - use default test ad server
-    /// 2) advanced - use custom ad server
-    #[clap(short, long, value_enum, verbatim_doc_comment, default_value_t = AdServerMode::Default)]
-    ad_server_mode: AdServerMode,
-
     /// Ad insertion mode to use:
     /// 1) static  - add intertistial every 30 seconds (100 in total).
     /// 2) dynamic - add intertistial when requested (Live Content only).
     #[clap(short, long, value_enum, verbatim_doc_comment, default_value_t = InsertionMode::Static)]
-    insertion_mode: InsertionMode,
+    ad_insertion_mode: InsertionMode,
 
     /// Base URL for interstitals (protocol://ip:port)
     /// If not provided, the server will use 'localhost' and the 'listen port' as the base URL
     /// e.g., http://localhost:${LISTEN_PORT}
-    #[clap(long, verbatim_doc_comment, default_value_t = String::from(""))]
+    #[clap(short, long, verbatim_doc_comment, default_value_t = String::from(""))]
     interstitals_address: String,
-}
-
-#[derive(ValueEnum, Clone, Debug, PartialEq)]
-pub enum AdServerMode {
-    Default,
-    Advanced,
-}
-
-impl AdServerMode {
-    pub fn to_str(&self) -> &str {
-        match self {
-            AdServerMode::Default => "default",
-            AdServerMode::Advanced => "advanced",
-        }
-    }
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
@@ -128,7 +180,6 @@ struct ServerConfig {
     interstitials_address: Url,
     master_playlist_path: String,
     insertion_mode: InsertionMode,
-    ad_server_mode: AdServerMode,
 }
 
 impl ServerConfig {
@@ -137,14 +188,21 @@ impl ServerConfig {
         interstitials_address: Url,
         master_playlist_path: String,
         insertion_mode: InsertionMode,
-        ad_server_mode: AdServerMode,
     ) -> Self {
         Self {
             forward_url,
             interstitials_address,
             master_playlist_path,
             insertion_mode,
-            ad_server_mode,
+        }
+    }
+
+    fn to_json(&self) -> json::JsonValue {
+        object! {
+            "forward_url": self.forward_url.as_str(),
+            "interstitials_address": self.interstitials_address.as_str(),
+            "master_playlist_path": self.master_playlist_path.clone(),
+            "insertion_mode": self.insertion_mode.to_str(),
         }
     }
 }
@@ -155,24 +213,6 @@ struct InsertionCommand {
     duration: u64,
     pod_num: u64,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct AdSlot {
-    id: Uuid,
-    index: u64,
-    start_time: chrono::DateTime<chrono::Local>,
-    duration: u64,
-    pod_num: u64,
-}
-
-impl AdSlot {
-    fn name(&self) -> String {
-        format!("ad_slot{}", self.index)
-    }
-}
-
-#[derive(Clone, Default)]
-struct AvailableAdSlots(Arc<DashSet<AdSlot>>);
 
 impl InsertionCommand {
     fn from_query(query: &str) -> Result<Self, String> {
@@ -206,24 +246,17 @@ fn get_request_type(req: &HttpRequest, config: &web::Data<ServerConfig>) -> Requ
         return RequestType::MasterPlayList;
     } else if path.contains(".ts") || path.contains(".cmf") || path.contains(".mp") {
         return RequestType::Segment;
-    } else {
+    } else if path.contains(".m3u8") {
         return RequestType::MediaPlayList;
+    } else {
+        return RequestType::Other;
     }
-}
-
-fn get_query_param(req: &HttpRequest, key: &str) -> Option<String> {
-    req.uri().query().and_then(|query| {
-        url::form_urlencoded::parse(query.as_bytes())
-            .find(|(k, _)| k == key)
-            .map(|(_, v)| v.to_string())
-    })
 }
 
 fn build_ad_server_url(
     ad_server_url: &Url,
     interstitial_id: &str,
     user_id: &str,
-    config: &web::Data<ServerConfig>,
     available_slots: &web::Data<AvailableAdSlots>,
 ) -> Result<Url, Error> {
     let slot = available_slots
@@ -232,19 +265,41 @@ fn build_ad_server_url(
         .find(|slot| slot.name() == interstitial_id)
         .ok_or_else(|| error::ErrorNotFound("Ad slot missing".to_string()))?;
 
-    let ad_url = match config.ad_server_mode {
-        AdServerMode::Default => {
-            build_test_ad_server_url(ad_server_url, slot.duration, slot.pod_num, user_id)
-        }
-        AdServerMode::Advanced => build_advanced_ad_server_url(
-            ad_server_url,
-            slot.duration + BUMPER_DURATION,
-            slot.pod_num,
-            user_id,
-        ),
-    };
+    // Create a map of query templates to replace in the ad_server_url
+    let duration_str = slot.duration.to_string();
+    let pod_num_str = slot.pod_num.to_string();
+    let query_templates: HashMap<&str, &str> = [
+        (SESSION_ID_TEMPLATE, user_id),
+        (DURATION_TEMPLATE, &duration_str),
+        (POD_NUM_TEMPLATE, &pod_num_str),
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
-    Ok(ad_url)
+    // Extract and transform query parameters from the ad_server_url
+    let transformed_queries: String = ad_server_url
+        .query_pairs()
+        .map(|(key, value)| {
+            // Check if the value matches any template in query_templates
+            let new_value = if let Some(&matched_value) = query_templates.get(value.as_ref()) {
+                // Use the matched value if a template is found
+                matched_value.to_string()
+            } else {
+                // Otherwise, use the original value
+                value.into_owned()
+            };
+
+            format!("{}={}", key, new_value)
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+
+    // Clone the original URL and set the new query string
+    let mut updated_ad_server_url = ad_server_url.clone();
+    updated_ad_server_url.set_query(Some(&transformed_queries));
+
+    Ok(updated_ad_server_url)
 }
 
 fn build_ad_response(
@@ -252,16 +307,10 @@ fn build_ad_response(
     req_url: Url,
     interstitial_id: &str,
     user_id: &str,
-    config: &web::Data<ServerConfig>,
     available_ads: web::Data<AvailableAds>,
 ) -> String {
-    let mut linears = get_all_linears_from_vast(&vast);
-    // FIX: This is a temporary way to skip the first and last bumper ads
-    // As they are fMP4 and require special handling
-    if config.ad_server_mode == AdServerMode::Advanced && linears.len() >= 3 {
-        linears = linears[1..linears.len() - 1].to_vec();
-    }
-
+    // Get all linears (regular MP4s) from the VAST
+    let linears = get_all_linears_from_vast(&vast);
     let mut accumulated_duration = 0;
     let assets = linears
         .iter()
@@ -271,8 +320,11 @@ fn build_ad_response(
             let ad = Ad {
                 duration,
                 url: urls.first().unwrap().clone(),
+                requested_at: chrono::Local::now(),
             };
+            // Transform the linears into ads and save them for follow-up requests
             available_ads.linears.insert(linear_id, ad);
+
             let start_offset = accumulated_duration;
             accumulated_duration += duration;
 
@@ -325,6 +377,11 @@ fn insert_interstitials(
         .is_some_and(|t| t == hls_m3u8::types::PlaylistType::Vod);
     let is_dynamic = *ad_insert_mode == InsertionMode::Dynamic;
 
+    if is_vod && is_dynamic {
+        log::error!("Dynamic ad insertion is not supported for VOD streams.");
+        return;
+    }
+
     // Take the first program date time as the start for VOD stream
     // Or the start time of the server for Live stream
     let init_program_date_time = if is_vod {
@@ -334,7 +391,7 @@ fn insert_interstitials(
     };
 
     // Generate ad slot every half a minute for static mode by default
-    let fixed_ad_slots: Vec<AdSlot> = (1..100)
+    let fixed_ad_slots: Vec<AdSlot> = (1..DEFAULT_AD_NUMBER)
         .map(|i| {
             let seconds = i * 30;
             let start_time = init_program_date_time + chrono::Duration::seconds(seconds);
@@ -478,14 +535,18 @@ async fn handle_commands(
                     "pod_num": command.pod_num,
                 }
             };
-            Ok(HttpResponse::Ok().json(response.dump()))
+            Ok(HttpResponse::Ok()
+                .content_type(mime::APPLICATION_JSON)
+                .body(response.pretty(2)))
         }
         Err(err) => {
             let response = object! {
                 status: "error",
                 message: err
             };
-            Ok(HttpResponse::BadRequest().json(response.dump()))
+            Ok(HttpResponse::BadRequest()
+                .content_type(mime::APPLICATION_JSON)
+                .body(response.pretty(2)))
         }
     }
 }
@@ -495,7 +556,6 @@ async fn handle_interstitials(
     ad_server_url: web::Data<Url>,
     available_ads: web::Data<AvailableAds>,
     available_slots: web::Data<AvailableAdSlots>,
-    config: web::Data<ServerConfig>,
     client: web::Data<Client>,
 ) -> Result<HttpResponse, Error> {
     let ad_server_url = ad_server_url.clone();
@@ -512,13 +572,7 @@ async fn handle_interstitials(
     }
     log::info!("Received interstitial request from user {user_id} for slot {interstitial_id}");
 
-    let ad_url = build_ad_server_url(
-        &ad_server_url,
-        &interstitial_id,
-        &user_id,
-        &config,
-        &available_slots,
-    )?;
+    let ad_url = build_ad_server_url(&ad_server_url, &interstitial_id, &user_id, &available_slots)?;
     log::info!("Request ad pod with url {ad_url}");
 
     let mut res = client
@@ -537,14 +591,7 @@ async fn handle_interstitials(
         // Return an empty VAST in case of parsing error
         .unwrap_or_default();
 
-    let response = build_ad_response(
-        vast,
-        req_url,
-        &interstitial_id,
-        &user_id,
-        &config,
-        available_ads,
-    );
+    let response = build_ad_response(vast, req_url, &interstitial_id, &user_id, available_ads);
     log::info!("asset json reply \n{response}");
 
     Ok(HttpResponse::Ok()
@@ -574,19 +621,21 @@ async fn handle_follow_up_request(
         .build()
         .unwrap();
 
+    // Wrap the MP4 in a media playlist
     let m3u8 = MediaPlaylist::builder()
         .media_sequence(0)
         .target_duration(Duration::from_secs(linear.duration))
         .segments(vec![segment])
         .has_end_list(true)
         .build()
+        .inspect(|m3u8| {
+            log::debug!("m3u8 \n{m3u8}");
+        })
         .unwrap();
 
-    let mut client_resp = HttpResponse::build(actix_web::http::StatusCode::OK);
-    client_resp.insert_header(("content-type", "application/vnd.apple.mpegurl"));
-    log::debug!("m3u8 \n{m3u8}");
-
-    Ok(client_resp.body(m3u8.to_string()))
+    Ok(HttpResponse::Ok()
+        .content_type("application/vnd.apple.mpegurl")
+        .body(m3u8.to_string()))
 }
 
 async fn handle_media_stream(
@@ -604,6 +653,7 @@ async fn handle_media_stream(
             handle_media_playlist(req, available_slots, config, client).await
         }
         RequestType::Segment => handle_segment(req, config, client).await,
+        RequestType::Other => Ok(HttpResponse::NotFound().finish()),
     }
 }
 
@@ -646,7 +696,7 @@ async fn handle_media_playlist(
     let mut m3u8 = MediaPlaylist::try_from(manifest).unwrap();
 
     insert_interstitials(&mut m3u8, &config, available_slots);
-    log::info!("m3u8 \n{m3u8}");
+    log::debug!("m3u8 \n{m3u8}");
 
     Ok(HttpResponse::Ok()
         .content_type("application/vnd.apple.mpegurl")
@@ -669,6 +719,24 @@ async fn handle_segment(
     copy_headers(&res, &mut client_resp);
 
     Ok(client_resp.streaming(res))
+}
+
+async fn handle_status(
+    config: web::Data<ServerConfig>,
+    available_ads: web::Data<AvailableAds>,
+    available_slots: web::Data<AvailableAdSlots>,
+) -> Result<HttpResponse, Error> {
+    // Return the status of the server
+    let response = object! {
+        "config": config.to_json(),
+        "available_ads": available_ads.to_json(),
+        "available_slots": available_slots.to_json(),
+    }
+    .pretty(2);
+
+    Ok(HttpResponse::Ok()
+        .content_type(mime::APPLICATION_JSON)
+        .body(response))
 }
 
 #[actix_web::main]
@@ -700,9 +768,8 @@ async fn main() -> io::Result<()> {
     log::info!("Program started at: {:?}", *START_TIME);
     log::info!("Starting HTTP server at {listen_url}, fowarding to {forward_url}, interstials' base URL: {interstitials_address}");
     log::info!(
-        "Ad server endpoint: {ad_server_url}, {:?} mode, {:?} insertion",
-        args.ad_server_mode.to_str(),
-        args.insertion_mode.to_str()
+        "Ad server endpoint: {ad_server_url}, {:?} insertion",
+        args.ad_insertion_mode.to_str()
     );
 
     let client_tls_config = Arc::new(rustls_config());
@@ -712,8 +779,7 @@ async fn main() -> io::Result<()> {
         forward_url,
         interstitials_address,
         playlist_path.to_string(),
-        args.insertion_mode,
-        args.ad_server_mode,
+        args.ad_insertion_mode,
     );
     HttpServer::new(move || {
         let cors = actix_cors::Cors::permissive();
@@ -735,6 +801,7 @@ async fn main() -> io::Result<()> {
             .wrap(middleware::Logger::default())
             .wrap(cors)
             .route(COMMAND_PREFIX, web::get().to(handle_commands))
+            .route(STATUS_PREFIX, web::get().to(handle_status))
             .route(INTERSTITIAL_PLAYLIST, web::get().to(handle_interstitials))
             .default_service(web::to(handle_media_stream))
     })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,12 @@ pub fn get_all_linears_from_vast<'a>(vast: &'a vast4_rs::Vast<'a>) -> Vec<vast4_
                     .creatives
                     .iter()
                     .filter_map(|createve| createve.linear.clone())
+                    .filter(|linear| {
+                        let media_urls = get_media_urls_from_linear(linear);
+                        // Only return linears with mp4 media files.
+                        // This is a simple way to filter out bumpers (which end with '*_2023_P8_mp4').
+                        !media_urls.is_empty() && media_urls.first().unwrap().ends_with(".mp4")
+                    })
                     .collect::<Vec<_>>()
             })
         })
@@ -95,44 +101,10 @@ pub fn build_forward_url(req: &HttpRequest, forward_url: &Url) -> Url {
     new_url
 }
 
-pub fn build_advanced_ad_server_url(
-    server_url: &Url,
-    duration: u64,
-    _pod_num: u64,
-    user_id: &str,
-) -> Url {
-    let mut ad_url = server_url.clone();
-    ad_url
-        .query_pairs_mut()
-        .clear()
-        .append_pair("duration", &duration.to_string())
-        .append_pair("channelId", "20007")
-        .append_pair("userId", user_id)
-        .append_pair("deviceType", "stb")
-        .append_pair("os", "ios")
-        .append_pair("screenSize", "960x540")
-        .append_pair("geolocation", "176.71.21.0")
-        .append_pair("useg", "a50-54,p4714,gm")
-        .append_pair("adLimit", "0");
-
-    ad_url
-}
-
-pub fn build_test_ad_server_url(
-    server_url: &Url,
-    duration: u64,
-    pod_num: u64,
-    user_id: &str,
-) -> Url {
-    let mut ad_url = server_url.clone();
-    ad_url
-        .query_pairs_mut()
-        .append_pair("uid", user_id)
-        .append_pair("dur", &duration.to_string())
-        .append_pair("max", "5")
-        .append_pair("min", "5")
-        .append_pair("skip", "2")
-        .append_pair("pod", &pod_num.to_string());
-
-    ad_url
+pub fn get_query_param(req: &HttpRequest, key: &str) -> Option<String> {
+    req.uri().query().and_then(|query| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.to_string())
+    })
 }


### PR DESCRIPTION
Now it is possible to specify a few templates in the ad server URL to be filled by the proxy server.
Here are the possible templates:

- [template.sessionId] - a unique marker for the user session
- [template.duration] - the targeted ad break duration
- [template.pod] - the targeted ad number in the break

For example, one could specify the Test Ad Server URL to be `https://eyevinn-sgai.eyevinn-test-adserver.auto.prod.osaas.io/api/v1/vast?dur=[template.duration]&uid=[template.sessionId]&ps=[template.pod]&min=5&max=5`. 
Then the query param '[template.duration]' would be replaced by the actual ad break duration '10' so the request towards Test Ad Server would look like `https://eyevinn-sgai.eyevinn-test-adserver.auto.prod.osaas.io/api/v1/vast?dur=10&uid=test&ps=2&min=5&max=5`

In addition, it is also possible for clients to attach additional query parameters to forward to the ad server.
For example, if a client starts the playback with `http://127.0.0.1:3333/loop/master.m3u8?custom=test`. 
Then the request towards Test Ad Server would include `custom=test` too. However, this approach has limitations in the case of multiple clients. The query parameters from the last client would overwrite the previous ones. To fix that, one must recognise every client and attach their **individual** query parameters to the ad server requests.

Apart from the above, a new 'status' handler is available to check the configuration, available ads and slots.