### PR TITLE
feat: support VoD stream without PROGRAM-DATE-TIME tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ fileSequence18.ts
 
 ## Limitations
 
-* In order to place the interstitials at the correct timepoints, the origin media playlist must contain the `EXT-X-PROGRAM-DATE-TIME` tag. Otherwise, no interstitials will be inserted (the origin media playlist will be returned).
+* In order to place the interstitials at the correct timepoints, the origin media playlist should contain the `EXT-X-PROGRAM-DATE-TIME` tag. For Live stream, the origin media playlist will be returned
+if this tag is not found so no interstitials will be inserted. For VoD, the proxy server will try to use its starting time as reference if the `EXT-X-PROGRAM-DATE-TIME` tag is not found.
 * The creatives from ad server are mostly regular MPEG-4 files (ftyp+moov+mdat). While AVPlayer can handle regular MP4 files, other video player like hls.js can only handle fragmented MPEG-4 files (ftyp+moov+moof+mdat+moof+mdat+…). Therefore, it would fail to play out the interstitials.
 Ideally, raw MP4 creatives should be transcoded to fMP4 or TS files first. One can do that manually or use the [encore](https://github.com/svt/encore) to transocde them into HLS stream and store the URL in a CouchDB instance.
 * Joining the live stream during an ad break might pause the playback until the ad break is over.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,18 @@ pub fn fixed_offset_to_local(
     date.with_timezone(&chrono::Local)
 }
 
+pub fn parse_date_time(
+    date_time: &str,
+) -> chrono::ParseResult<chrono::DateTime<chrono::FixedOffset>> {
+    let default_date_time_format = "%Y-%m-%dT%H:%M:%S%.3f%z";
+
+    let date_time = chrono::DateTime::parse_from_rfc3339(date_time)
+        .or_else(|_| chrono::DateTime::parse_from_rfc2822(date_time))
+        .or_else(|_| chrono::DateTime::parse_from_str(date_time, default_date_time_format));
+
+    date_time
+}
+
 /// Create simple rustls client config from root certificates.
 pub fn rustls_config() -> ClientConfig {
     rustls::crypto::aws_lc_rs::default_provider()


### PR DESCRIPTION
With this commit, we can now use VoD streams which do not have a `#EXT-X-PROGRAM-DATE-TIME` tag in their media playlist. 

We use the starting time of the program as the reference.

