### PR TITLE
fix: fix media playlist URI handling for querystring parameters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -564,6 +564,7 @@ fn replace_absolute_url_with_relative_url(m3u8: &mut MasterPlaylist) {
             let absolute_media_playlist_url = Url::parse(&uri).expect("Invalid media playlist URI");
             let mut relative_url = absolute_media_playlist_url.path().to_string();
             if let Some(query) = absolute_media_playlist_url.query() {
+                relative_url.push('?');
                 relative_url.push_str(query);
             }
 


### PR DESCRIPTION
While testing this out with [Mux Video](https://www.mux.com) I believe I found a bug where query parameters in the variant manifest URLs were not being handled correctly for what gets written into the main manifest payload. This was required to get this to work with Mux Video, but to be honest I'm not sure if this will cause issues elsewhere, for instance if the request coming into the proxy URL itself has query params. I think it's fine, but someone should be able to tell if this is the correct fix.

For what it's worth, I was testing with a live stream where the main manifest responded with the following:

```
#EXTM3U
#EXT-X-VERSION:5
#EXT-X-INDEPENDENT-SEGMENTS

#EXT-X-STREAM-INF:BANDWIDTH=2493700,AVERAGE-BANDWIDTH=2493700,CODECS="mp4a.40.2,avc1.640020",RESOLUTION=1280x720,CLOSED-CAPTIONS=NONE
https://manifest-gcp-us-east4-vop1.fastly.mux.com/W02wiQ4zLMsa3jn3ZPTbu1H8GhhHHgGXBUU01DvEF02gUSHw6I4QP4GfjL9lZXEYlvhQRgp2Hq4nTy1J8Mh00GngmQ/rendition.m3u8?cdn=edgemv&exclude_pdt=false&expires=1761915600&live=1&skid=default&signature=NjkwNGI2YjhfYjY1ZjExZTdkMGI4YWE4Y2Q3MzcyNzIwZjdjMDkzNWZmOTc4OGEzNWVjYTAwMTk5NzRjNTNhZDU4OTljODViOA==&vsid=DN00Gg7jAtwu3aaPJaqtu002VcbfUh4vYi00NSvDo8nRL1haqMrShQCiSvn7MFfu35DNdctoRmp02GU
#EXT-X-STREAM-INF:BANDWIDTH=1240800,AVERAGE-BANDWIDTH=1240800,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=854x480,CLOSED-CAPTIONS=NONE
https://manifest-gcp-us-east4-vop1.fastly.mux.com/IiZaDH8DQXthlCH0002AGx02KVVRCR01ibBvuQ9pR2NF3EcqF1HI00ka4QPZzolhE4XrfQq6KLQeYBATsmd6TpaMvd1EiUU02z6uQ4rbNZls8x018A/rendition.m3u8?cdn=edgemv&exclude_pdt=false&expires=1761915600&live=1&skid=default&signature=NjkwNGI2YjhfZTBmZjFlZGNlNmFmZGQ3YmVkNDk4YThiZDZmYTg0NTc0YzQyY2I0ZTAxZTY1NDc5NDlkODQxMGU2NDZkNzE2YQ==&vsid=DN00Gg7jAtwu3aaPJaqtu002VcbfUh4vYi00NSvDo8nRL1haqMrShQCiSvn7MFfu35DNdctoRmp02GU
#EXT-X-STREAM-INF:BANDWIDTH=595100,AVERAGE-BANDWIDTH=595100,CODECS="mp4a.40.2,avc1.64001e",RESOLUTION=480x270,CLOSED-CAPTIONS=NONE
https://manifest-gcp-us-east4-vop1.fastly.mux.com/gQFPA1T01W00LHZ2uhZnja8P1wcWC4ipFM3t6lCKuF4ZHHoSv1FAk7WVm4e401E9dtz021qcUuN37MonjzA00Kk02vJw/rendition.m3u8?cdn=edgemv&exclude_pdt=false&expires=1761915600&live=1&skid=default&signature=NjkwNGI2YjhfYWVmYmU3ZmJlYWI0ODFkY2I1YWNmOTQ1ZWRkNTZjZWQzNWM4Y2E3Y2I1YjU2NTEwZTU5Y2I0YjcyMTNkNDhjYw==&vsid=DN00Gg7jAtwu3aaPJaqtu002VcbfUh4vYi00NSvDo8nRL1haqMrShQCiSvn7MFfu35DNdctoRmp02GU
```

Without this fix, the proxied URLs ended up of the format `/W02wiQ4zLMsa3jn3ZPTbu1H8GhhHHgGXBUU01DvEF02gUSHw6I4QP4GfjL9lZXEYlvhQRgp2Hq4nTy1J8Mh00GngmQ/rendition.m3u8cdn=edgemv&exc...` instead of `/W02wiQ4zLMsa3jn3ZPTbu1H8GhhHHgGXBUU01DvEF02gUSHw6I4QP4GfjL9lZXEYlvhQRgp2Hq4nTy1J8Mh00GngmQ/rendition.m3u8?cdn=edgemv&exc...`