### PR TITLE
fix: support ORIGIN_HOST env variable in Docker entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,20 @@ if [ -z "$VAST_ENDPOINT" ]; then
   exit 1
 fi
 
-if [ -z "$ORIGIN_URL" ]; then
-  echo "ORIGIN_URL is required"
+if [ -z "$ORIGIN_HOST" ] && [ -z "$ORIGIN_URL" ]; then
+  echo "Either ORIGIN_HOST or ORIGIN_URL is required"
   exit 1
+fi
+
+# Build origin argument: prefer ORIGIN_HOST (--origin-host) over ORIGIN_URL (positional)
+if [ -n "$ORIGIN_HOST" ]; then
+  ORIGIN_ARG="--origin-host ${ORIGIN_HOST}"
+else
+  ORIGIN_ARG="${ORIGIN_URL}"
 fi
 
 /app/ad_proxy 0.0.0.0 ${PORT:-8080} \
   ${VAST_ENDPOINT} \
-  ${ORIGIN_URL} \
+  ${ORIGIN_ARG} \
   --ad-insertion-mode ${INSERTION_MODE:-static} \
   --interstitials-address https://${OSC_HOSTNAME}


### PR DESCRIPTION
## Summary
- Update entrypoint.sh to support the new `--origin-host` CLI option via `ORIGIN_HOST` environment variable
- Maintain backwards compatibility with existing `ORIGIN_URL` environment variable

## Usage

**Backwards compatible (specific playlist URL):**
```bash
docker run -e VAST_ENDPOINT=https://ad-server/vast \
           -e ORIGIN_URL=http://origin.com/stream/master.m3u8 \
           ad_proxy
```

**New origin host mode (proxy any stream):**
```bash
docker run -e VAST_ENDPOINT=https://ad-server/vast \
           -e ORIGIN_HOST=http://origin.com \
           ad_proxy
```

## Test plan
- [ ] Verify container works with `ORIGIN_URL` only (backwards compatible)
- [ ] Verify container works with `ORIGIN_HOST` only (new mode)
- [ ] Verify container fails with helpful message when neither is set
- [ ] Verify `ORIGIN_HOST` takes precedence if both are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)